### PR TITLE
useSavedTheme Hook

### DIFF
--- a/src/@types/themeData.ts
+++ b/src/@types/themeData.ts
@@ -1,0 +1,17 @@
+export type ThemeData = {
+  name: string;
+  colors: {[k: string]: SaturatedColor | string}
+};
+
+export type SaturatedColor = {
+  sat50: string,
+  sat100: string,
+  sat200: string,
+  sat300: string,
+  sat400: string,
+  sat500: string,
+  sat600: string,
+  sat700: string,
+  sat800: string,
+  sat900: string,
+};

--- a/src/app/hooks/isVercelLoading.ts
+++ b/src/app/hooks/isVercelLoading.ts
@@ -1,0 +1,3 @@
+const isVercelLoading = () => typeof window === 'undefined';
+
+export default isVercelLoading;

--- a/src/app/hooks/useSavedTheme.ts
+++ b/src/app/hooks/useSavedTheme.ts
@@ -1,0 +1,29 @@
+import { useMemo, useState } from 'react';
+
+import { DARK_THEME } from '@/consts';
+import type { ThemeData } from '@/@types/themeData';
+import { dark, light } from '@/style/Theme.styled';
+
+import isVercelLoading from './isVercelLoading';
+
+const THEME_KEY = 'current-theme';
+
+const useSavedTheme = (): [ThemeData, () => void] => {
+  const localStorageTheme = useMemo(() => {
+    if (isVercelLoading()) return light;
+    const theme = localStorage.getItem(THEME_KEY);
+    return theme === DARK_THEME ? dark : light;
+  }, []);
+
+  const [savedTheme, setSavedTheme] = useState(localStorageTheme);
+
+  const toggleTheme = () => {
+    const newTheme = savedTheme.name === DARK_THEME ? light : dark;
+    setSavedTheme(newTheme);
+    localStorage.setItem(THEME_KEY, newTheme.name);
+  };
+
+  return [savedTheme, toggleTheme];
+};
+
+export default useSavedTheme;

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,5 +1,5 @@
 'use client';
-import React, { useState } from 'react';
+import React from 'react';
 import StyledComponentsRegistry from '@/lib/registry';
 import { GlobalStyle } from '@/style/global';
 
@@ -7,7 +7,7 @@ import { Poppins } from 'next/font/google';
 import { ThemeProvider } from 'styled-components';
 import { LoginPage, Navbar, Page, PageLink } from '@/app/style';
 import ThemeSelector from '@/components/molecules/ThemeSelector/ThemeSelctor';
-import { dark } from '@/style/Theme.styled';
+import useSavedTheme from './hooks/useSavedTheme';
 
 const poppins = Poppins({
   weight: ['100', '200', '300', '400', '500', '600', '700', '800', '900'],
@@ -39,17 +39,14 @@ export default function RootLayout({
 }: Readonly<{
   children: React.ReactNode;
 }>) {
-  const [theme, setTheme] = useState(dark);
-  const handleCallBack = (data: any) => {
-    setTheme(data);
-  };
+  const [theme, themeToggler] = useSavedTheme();
   return (
     <html lang='en'>
       <body className={poppins.className}>
         <StyledComponentsRegistry>
           <ThemeProvider theme={theme}>
             <NavBarComponent />
-            <ThemeSelector themeSelected={handleCallBack} />
+            <ThemeSelector selectedTheme={theme} themeToggle={themeToggler} />
             {children}
             <GlobalStyle />
           </ThemeProvider>

--- a/src/components/molecules/ThemeSelector/ThemeSelctor.tsx
+++ b/src/components/molecules/ThemeSelector/ThemeSelctor.tsx
@@ -1,34 +1,12 @@
-import React, { useMemo, useState } from 'react';
-import { DARK_THEME } from '@/consts';
 import { FaMoon, FaSun } from 'react-icons/fa';
+import { DARK_THEME } from '@/consts';
+import type { ThemeData } from '@/@types/themeData';
 import IconButton from '@/components/atoms/IconButton/IconButton';
-import { dark, light } from '@/style/Theme.styled';
 
-interface ThemeSelectorProps {
-  themeSelected: any;
-}
-
-const ThemeSelector = ({ themeSelected }: ThemeSelectorProps) => {
-  const isVercelLoading = () => typeof window === 'undefined';
-
-  const localTheme = useMemo(() => {
-    if (isVercelLoading()) return light;
-    const theme = localStorage.getItem('current-theme');
-    return theme === DARK_THEME ? dark : light;
-  }, []);
-
-  const [selectedTheme, setSelectedTheme] = useState(localTheme);
-
-  const handleThemeChange = (theme: string) => {
-    setSelectedTheme(theme === DARK_THEME ? light : dark);
-    localStorage.setItem('current-theme', theme);
-    themeSelected(selectedTheme);
-  };
+const ThemeSelector = ({ selectedTheme, themeToggle }: { selectedTheme: ThemeData, themeToggle: () => void }) => {
   return (
     <IconButton
-      onClick={() => {
-        handleThemeChange(selectedTheme.name);
-      }}
+      onClick={themeToggle}
       icon={selectedTheme.name === DARK_THEME ? <FaMoon /> : <FaSun />}
     />
   );

--- a/src/style/Theme.styled.ts
+++ b/src/style/Theme.styled.ts
@@ -1,6 +1,7 @@
+import type { SaturatedColor, ThemeData } from '@/@types/themeData';
 import { DARK_THEME, LIGHT_THEME } from '@/consts';
 
-const cyan = {
+const cyan: SaturatedColor = {
   sat50: '#EDFDFD',
   sat100: '#C4F1F9',
   sat200: '#9DECF9',
@@ -13,7 +14,7 @@ const cyan = {
   sat900: '#065666',
 };
 
-const gray = {
+const gray: SaturatedColor = {
   sat50: '#f7fafc',
   sat100: '#EDF2F7',
   sat200: '#E2E8F0',
@@ -26,7 +27,7 @@ const gray = {
   sat900: '#171923',
 };
 
-const red = {
+const red: SaturatedColor = {
   sat50: '#FFF5F5',
   sat100: '#FED7D7',
   sat200: '#FEB2B2',
@@ -39,7 +40,7 @@ const red = {
   sat900: '#63171B',
 };
 
-const orange = {
+const orange: SaturatedColor = {
   sat50: '#FFFAF0',
   sat100: '#FEEBC8',
   sat200: '#FBD38D',
@@ -52,7 +53,7 @@ const orange = {
   sat900: '#652B19',
 };
 
-const blue = {
+const blue: SaturatedColor = {
   sat50: '#EBF8FF',
   sat100: '#BEE3F8',
   sat200: '#90CDF4',
@@ -65,7 +66,7 @@ const blue = {
   sat900: '#1A365D',
 };
 
-const purple = {
+const purple: SaturatedColor = {
   sat50: '#FAF5FF',
   sat100: '#E9D8FD',
   sat200: '#D6BCFA',
@@ -78,7 +79,7 @@ const purple = {
   sat900: '#322659',
 };
 
-const pink = {
+const pink: SaturatedColor = {
   sat50: '#FFF5F7',
   sat100: '#FED7E2',
   sat200: '#FBB6CE',
@@ -91,7 +92,7 @@ const pink = {
   sat900: '#521B41',
 };
 
-const green = {
+const green: SaturatedColor = {
   sat50: '#F0FFF4',
   sat100: '#C6F6D5',
   sat200: '#9AE6B4',
@@ -103,7 +104,7 @@ const green = {
   sat800: '#22543D',
   sat900: '#1C4532',
 };
-const yellow = {
+const yellow: SaturatedColor = {
   sat50: '#FFFFF0',
   sat100: '#FEFCBF',
   sat200: '#FAF089',
@@ -115,7 +116,7 @@ const yellow = {
   sat800: '#744210',
   sat900: '#5F370E',
 };
-const teal = {
+const teal: SaturatedColor = {
   sat50: '#E6FFFA',
   sat100: '#B2F5EA',
   sat200: '#81E6D9',
@@ -128,7 +129,7 @@ const teal = {
   sat900: '#1D4044',
 };
 
-export const light = {
+export const light: ThemeData = {
   name: LIGHT_THEME,
   colors: {
     background: '#f8f8f8',
@@ -148,7 +149,7 @@ export const light = {
   },
 };
 
-export const dark = {
+export const dark: ThemeData = {
   name: DARK_THEME,
   colors: {
     background: '#242423',


### PR DESCRIPTION
## Problem
We had some issues when trying to extract theme loading logic as a hook.

## Solution
This PR implements the desired hook and changes the relevant components and pages.

## Changes
- New types for ThemeData and SaturatedColors
- useSavedTheme Hook
- Root layout changes to use the hook

## References
Relevant for PR #22 