### PR TITLE
Fix database edition replacing int with string

### DIFF
--- a/src/app/database/components/value-node.tsx
+++ b/src/app/database/components/value-node.tsx
@@ -1,6 +1,7 @@
 import { useContext, useState } from 'react';
 import recursiveValueUpdate from '../utils/recursiveValueUpdate';
 import DatabaseContext from '../context';
+import numberParsing from '../utils/numberParsing';
 
 const ValueNode = ({ value, path }: { value: any, path: string[] }) => {
   const [localState, setLocalState] = useContext(DatabaseContext);
@@ -10,7 +11,7 @@ const ValueNode = ({ value, path }: { value: any, path: string[] }) => {
 
   const handleSubmit = (e: any) => {
     if (e.key !== 'Enter') return;
-    updateValue((e.target as HTMLInputElement).value, path);
+    updateValue(numberParsing((e.target as HTMLInputElement).value), path);
     setIsEditing(false);
   };
 

--- a/src/app/database/utils/numberParsing.ts
+++ b/src/app/database/utils/numberParsing.ts
@@ -1,0 +1,3 @@
+const numberParsing = (input: string) => isNaN(Number(input)) ? input : Number(input);
+
+export default numberParsing;


### PR DESCRIPTION
## Problem
Values edited from the _database page_ would be of type `string`, bugging the player increment functions.

## Solution
Include conditional value parsing before saving values on the editor page.

## Changes
- [x] Create new function for conditional parsing;
- [x] Use the created function on database editor page;
- [x] Update all number values from the database page to save typing.

## References
Closes #29 
